### PR TITLE
20 post print 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,8 @@ jobs:
             mv config/database.yml.circleci config/database.yml &&
             mv config/integration_passcode.yml.circleci config/integration_passcode.yml &&
             mkdir app/parsing_files &&
-            mkdir public/psu
+            mkdir spec/fixtures/post_prints &&
+            mkdir public/psu &&
             mkdir public/log
 
       - run:

--- a/.gitignore
+++ b/.gitignore
@@ -30,9 +30,11 @@ spec/examples.txt
 /spec/fixtures/files/*
 /data/*
 /app/parsing_files/*
+/app/post_prints/*
 *.swp
 /config/activity_insight.yml
 /config/integration_passcode.yml
 /public/psu
 /public/log
+/public/post_prints
 /coverage

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ spec/examples.txt
 /data/*
 /app/parsing_files/*
 /app/post_prints/*
+/spec/fixtures/post_prints/*
 *.swp
 /config/activity_insight.yml
 /config/integration_passcode.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,10 @@ FROM ruby:2.7.3
 RUN mkdir /fams_tools
 WORKDIR /fams_tools
 
+RUN apt-get clean
 RUN apt-get update
-# For unzipping
-RUN apt-get install unzip
+# For zipping and unzipping
+RUN apt-get install -y zip unzip
 # Packages for webkit
 RUN apt-get install -y g++ qt5-default libqt5webkit5-dev gstreamer1.0-plugins-base gstreamer1.0-tools gstreamer1.0-x xvfb
 

--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,12 @@ gem 'bootstrap'
 # Jquery for dom manipulation
 gem 'jquery-rails'
 
+# PDF Reader
+gem 'pdf-reader'
+
+# ExifTool for parsing PDF metadata
+gem 'exiftool_vendored', '~> 12.33'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    Ascii85 (1.1.0)
     actioncable (5.2.6)
       actionpack (= 5.2.6)
       nio4r (~> 2.0)
@@ -44,6 +45,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
+    afm (0.2.2)
     airbrussh (1.4.0)
       sshkit (>= 1.6.1, != 1.7.0)
     anystyle (1.3.10)
@@ -137,6 +139,10 @@ GEM
     ed25519 (1.2.4)
     erubi (1.10.0)
     execjs (2.7.0)
+    exiftool (1.2.4)
+      json
+    exiftool_vendored (12.41.0)
+      exiftool (>= 0.7.0)
     factory_bot (5.1.1)
       activesupport (>= 4.2.0)
     ffi (1.11.1)
@@ -146,6 +152,7 @@ GEM
     globalid (1.0.0)
       activesupport (>= 5.0)
     hashdiff (1.0.0)
+    hashery (2.1.2)
     headless (2.3.1)
     htmlentities (4.3.4)
     http (4.2.0)
@@ -209,6 +216,12 @@ GEM
     parallel (1.19.1)
     parser (2.7.0.4)
       ast (~> 2.4.0)
+    pdf-reader (2.10.0)
+      Ascii85 (~> 1.0)
+      afm (~> 0.2.1)
+      hashery (~> 2.0)
+      ruby-rc4
+      ttfunk
     popper_js (1.14.5)
     public_suffix (4.0.6)
     puma (4.3.10)
@@ -280,6 +293,7 @@ GEM
       unicode-display_width (>= 1.4.0, < 1.7)
     ruby-ole (1.2.12.2)
     ruby-progressbar (1.10.1)
+    ruby-rc4 (0.1.5)
     ruby_dep (1.5.0)
     rubyzip (2.0.0)
     safe_yaml (1.0.5)
@@ -331,6 +345,7 @@ GEM
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.10)
+    ttfunk (1.7.0)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -385,6 +400,7 @@ DEPENDENCIES
   creek
   database_cleaner
   ed25519
+  exiftool_vendored (~> 12.33)
   factory_bot
   headless
   httparty
@@ -393,6 +409,7 @@ DEPENDENCIES
   mini_racer
   mysql2 (< 0.5)
   net-ldap
+  pdf-reader
   puma (~> 4.3)
   rails (~> 5.2.4)
   rails-controller-testing

--- a/app/controllers/post_prints_controller.rb
+++ b/app/controllers/post_prints_controller.rb
@@ -1,0 +1,64 @@
+class PostPrintsController < ApplicationController
+  def index
+    @analysis_files = collect_file_names
+  end
+
+  def analyze
+    clear_last_analysis
+    clear_pp_files
+    f_name = post_prints_csv.original_filename
+    f_path = File.join('app', 'post_prints', f_name)
+    File.open(f_path, "wb") { |f| f.write(post_prints_csv.read) }
+    errored_files = []
+    CSV.foreach(f_path, headers: true, encoding: "ISO8859-1:UTF-8", force_quotes: true, quote_char: '"', liberal_parsing: true) do |row|
+      sys = system("wget --header 'X-API-Key: #{api_key}' 'ai-s3-authorizer.k8s.libraries.psu.edu/api/v1/#{URI.escape(row['POST_FILE_1_DOC'])}' -P '#{post_prints_directory}'")
+      errored_files << row['POST_FILE_1_DOC'] if sys == false
+    end
+    File.open("#{post_prints_directory}/errors.txt", "wb") { |file| errored_files.each { |row| file << row } }
+    system("zip -9 -y -q -j #{analysis_directory}/post-print-analysis-#{DateTime.now.strftime('%FT%T').to_s}.zip #{post_prints_directory}/*")
+    clear_pp_files
+    redirect_to post_prints_path
+  end
+
+  private
+
+    def clear_pp_files
+      Dir.foreach(post_prints_directory) do |f|
+        fn = File.join(post_prints_directory, f)
+        File.delete(fn) if File.exist?(fn) && f != '.' && f != '..'
+      end
+    end
+
+    def clear_last_analysis
+      Dir.foreach(analysis_directory) do |f|
+        fn = File.join(analysis_directory, f)
+        File.delete(fn) if File.exist?(fn) && f != '.' && f != '..'
+      end
+    end
+
+    def post_prints_csv
+      params.require(:post_print_file)
+    end
+
+    def api_key
+      Rails.application.config_for(:activity_insight)['s3_bucket']['api_key']
+    end
+
+    def post_prints_directory
+      "#{Rails.root}/app/post_prints"
+    end
+
+    def analysis_directory
+      "#{Rails.root}/public/post_prints"
+    end
+
+    def collect_file_names
+      filenames = []
+      Dir.foreach("#{Rails.root}/public/post_prints") do |item|
+        next if ['.', '..'].include? item
+
+        filenames << item
+      end
+      filenames
+    end
+end

--- a/app/controllers/post_prints_controller.rb
+++ b/app/controllers/post_prints_controller.rb
@@ -4,52 +4,14 @@ class PostPrintsController < ApplicationController
   end
 
   def analyze
-    clear_last_analysis
-    clear_pp_files
-    f_name = post_prints_csv.original_filename
-    f_path = File.join('app', 'post_prints', f_name)
-    File.open(f_path, "wb") { |f| f.write(post_prints_csv.read) }
-    errored_files = []
-    CSV.foreach(f_path, headers: true, encoding: "ISO8859-1:UTF-8", force_quotes: true, quote_char: '"', liberal_parsing: true) do |row|
-      sys = system("wget --header 'X-API-Key: #{api_key}' 'ai-s3-authorizer.k8s.libraries.psu.edu/api/v1/#{URI.escape(row['POST_FILE_1_DOC'])}' -P '#{post_prints_directory}'")
-      errored_files << row['POST_FILE_1_DOC'] if sys == false
-    end
-    File.open("#{post_prints_directory}/errors.txt", "wb") { |file| errored_files.each { |row| file << row } }
-    system("zip -9 -y -q -j #{analysis_directory}/post-print-analysis-#{DateTime.now.strftime('%FT%T').to_s}.zip #{post_prints_directory}/*")
-    clear_pp_files
+    PostPrintAnalyzer.new(post_prints_csv).analyze
     redirect_to post_prints_path
   end
 
   private
 
-    def clear_pp_files
-      Dir.foreach(post_prints_directory) do |f|
-        fn = File.join(post_prints_directory, f)
-        File.delete(fn) if File.exist?(fn) && f != '.' && f != '..'
-      end
-    end
-
-    def clear_last_analysis
-      Dir.foreach(analysis_directory) do |f|
-        fn = File.join(analysis_directory, f)
-        File.delete(fn) if File.exist?(fn) && f != '.' && f != '..'
-      end
-    end
-
     def post_prints_csv
       params.require(:post_print_file)
-    end
-
-    def api_key
-      Rails.application.config_for(:activity_insight)['s3_bucket']['api_key']
-    end
-
-    def post_prints_directory
-      "#{Rails.root}/app/post_prints"
-    end
-
-    def analysis_directory
-      "#{Rails.root}/public/post_prints"
     end
 
     def collect_file_names

--- a/app/models/post_print_analyzer.rb
+++ b/app/models/post_print_analyzer.rb
@@ -2,6 +2,7 @@ class PostPrintAnalyzer
 
   def initialize(post_prints_csv)
     @post_prints_csv = post_prints_csv
+    @errored_files = []
   end
 
   def analyze
@@ -16,10 +17,9 @@ class PostPrintAnalyzer
 
   private
 
-    attr_accessor :post_prints_csv
+    attr_accessor :post_prints_csv, :errored_files
 
     def get_post_prints
-      errored_files = []
       CSV.foreach(f_path, headers: true, encoding: "ISO8859-1:UTF-8", force_quotes: true, quote_char: '"', liberal_parsing: true) do |row|
         next if row['POST_FILE_1_DOC'].blank?
 

--- a/app/models/post_print_analyzer.rb
+++ b/app/models/post_print_analyzer.rb
@@ -1,0 +1,62 @@
+class PostPrintAnalyzer
+
+  def initialize(post_prints_csv)
+    @post_prints_csv = post_prints_csv
+  end
+
+  def analyze
+    clear_last_analysis
+    clear_pp_files
+    File.open(f_path, "wb") { |f| f.write(post_prints_csv.read) }
+    get_post_prints
+    system("zip -9 -y -q -j #{analysis_directory}/post-print-analysis-#{DateTime.now.strftime('%FT%T').to_s}.zip #{post_prints_directory}/*")
+    clear_pp_files
+  end
+
+  private
+
+    attr_accessor :post_prints_csv
+
+    def get_post_prints
+      errored_files = []
+      CSV.foreach(f_path, headers: true, encoding: "ISO8859-1:UTF-8", force_quotes: true, quote_char: '"', liberal_parsing: true) do |row|
+        sys = system("wget --header 'X-API-Key: #{api_key}' 'ai-s3-authorizer.k8s.libraries.psu.edu/api/v1/#{URI.escape(row['POST_FILE_1_DOC'])}' -P '#{post_prints_directory}'")
+        errored_files << row['POST_FILE_1_DOC'] if sys == false
+      end
+      File.open("#{post_prints_directory}/errors.txt", "wb") { |file| errored_files.each { |row| file << row } }
+    end
+
+    def f_path
+      File.join('app', 'post_prints', f_name)
+    end
+
+    def f_name
+      post_prints_csv.original_filename
+    end
+
+    def clear_pp_files
+      Dir.foreach(post_prints_directory) do |f|
+        fn = File.join(post_prints_directory, f)
+        File.delete(fn) if File.exist?(fn) && f != '.' && f != '..'
+      end
+    end
+
+    def clear_last_analysis
+      Dir.foreach(analysis_directory) do |f|
+        fn = File.join(analysis_directory, f)
+        File.delete(fn) if File.exist?(fn) && f != '.' && f != '..'
+      end
+    end
+
+    def api_key
+      Rails.application.config_for(:activity_insight)['s3_bucket']['api_key']
+    end
+
+    def post_prints_directory
+      "#{Rails.root}/app/post_prints"
+    end
+
+    def analysis_directory
+      "#{Rails.root}/public/post_prints"
+    end
+end

--- a/app/models/post_print_analyzer.rb
+++ b/app/models/post_print_analyzer.rb
@@ -24,7 +24,7 @@ class PostPrintAnalyzer
         next if row['POST_FILE_1_DOC'].blank?
 
         sys = system("wget --header 'X-API-Key: #{api_key}' 'ai-s3-authorizer.k8s.libraries.psu.edu/api/v1/#{URI.escape(row['POST_FILE_1_DOC'])}' -P '#{post_prints_directory}'")
-        errored_files << row['POST_FILE_1_DOC'] if sys == false
+        errored_files << (row['POST_FILE_1_DOC'] + "\n") if sys == false
       end
       File.open("#{post_prints_directory}/errors.txt", "wb") { |file| errored_files.each { |row| file << row } }
     end

--- a/app/models/verify_post_print.rb
+++ b/app/models/verify_post_print.rb
@@ -65,7 +65,7 @@ class VerifyPostPrint
 
       PDF::Reader.open(file_path) do |reader|
         validation[:verbose] = reader.info
-        if reader.info.key? (:Subject)
+        if reader.info.key?(:Subject)
           begin
             if NOT_SUBJECTS.any? { |s| reader.info[:Subject].include?(s) }
               validation[:status] = false #good = false
@@ -105,9 +105,7 @@ class VerifyPostPrint
       validation[:message] = ""
       validation[:verbose] = ""
 
-      e = Exiftool.new(file_path)
-
-      h = e.to_hash
+      h = Exiftool.new(file_path).to_hash
       validation[:verbose] = h
       if !h[:journal_article_version].nil?
         # AM: accepted manuscript - pass

--- a/app/models/verify_post_print.rb
+++ b/app/models/verify_post_print.rb
@@ -41,6 +41,7 @@ class VerifyPostPrint
 
         wr_sheet.row(file_index).insert 3, exif_validation[:status]
         wr_sheet.row(file_index).insert 4, exif_validation[:message]
+        wr_sheet.row(file_index).insert 5, exif_validation[:journal_article_version]
       end
     end
     wr_book.write save_spreadsheet_name
@@ -106,18 +107,21 @@ class VerifyPostPrint
           @good_exif += 1
           validation[:status] = true
           validation[:message] = "accepted manuscript"
+          validation[:journal_article_version] = h[:journal_article_version]
           return validation
         end
         # P: proof - fail
         if h[:journal_article_version].downcase == "p"
           validation[:status] = false
           validation[:message] = "proof"
+          validation[:journal_article_version] = h[:journal_article_version]
           return validation
         end
         # VoR: version of record - fail
         if h[:journal_article_version].downcase == "vor"
           validation[:status] = false
           validation[:message] = "version of record"
+          validation[:journal_article_version] = h[:journal_article_version]
           return validation
         end
       end

--- a/app/models/verify_post_print.rb
+++ b/app/models/verify_post_print.rb
@@ -20,8 +20,8 @@ class VerifyPostPrint
   # list of unacceptable producers
   NOT_PRODUCERS = ["iText"]
 
-  HEADINGS = ["File", "PDF File Status", "PDF Status Message", "PDF Verbose", "EXIF File Status",
-              "EXIF Status Message", "Journal Article Version", "EXIF Verbose"]
+  HEADINGS = ["File", "PDF File Status", "PDF Status Message", "EXIF File Status",
+              "EXIF Status Message", "Journal Article Version"]
 
   def verify
     Dir.glob("#{directory_to_examine}/*.pdf").each_with_index do |file, file_index|
@@ -38,12 +38,9 @@ class VerifyPostPrint
 
         wr_sheet.row(file_index).insert 1, pdf_validation[:status]
         wr_sheet.row(file_index).insert 2, pdf_validation[:message]
-        wr_sheet.row(file_index).insert 3, pdf_validation[:verbose].inspect
 
-        wr_sheet.row(file_index).insert 4, exif_validation[:status]
-        wr_sheet.row(file_index).insert 5, exif_validation[:message]
-        wr_sheet.row(file_index).insert 6, exif_validation[:verbose][:journal_article_version]
-        wr_sheet.row(file_index).insert 7, exif_validation[:verbose].inspect
+        wr_sheet.row(file_index).insert 3, exif_validation[:status]
+        wr_sheet.row(file_index).insert 4, exif_validation[:message]
       end
     end
     wr_book.write save_spreadsheet_name
@@ -55,7 +52,6 @@ class VerifyPostPrint
       validation = {}
       validation[:status] = nil
       validation[:message] = ""
-      validation[:verbose] = ""
 
       if NOT_FILENAMES.any? { |s| file_path.include?(s) }
         validation[:status] = false
@@ -64,7 +60,6 @@ class VerifyPostPrint
       end
 
       PDF::Reader.open(file_path) do |reader|
-        validation[:verbose] = reader.info
         if reader.info.key?(:Subject)
           begin
             if NOT_SUBJECTS.any? { |s| reader.info[:Subject].include?(s) }
@@ -103,10 +98,8 @@ class VerifyPostPrint
       validation = {}
       validation[:status] = nil
       validation[:message] = ""
-      validation[:verbose] = ""
 
       h = Exiftool.new(file_path).to_hash
-      validation[:verbose] = h
       if !h[:journal_article_version].nil?
         # AM: accepted manuscript - pass
         if h[:journal_article_version].downcase == "am"

--- a/app/models/verify_post_print.rb
+++ b/app/models/verify_post_print.rb
@@ -1,0 +1,202 @@
+require 'pdf-reader'
+require 'exiftool_vendored'
+
+class VerifyPostPrint
+  def initialize
+    @good_pdf = 0
+    @good_exif = 0
+    @wr_book = Spreadsheet::Workbook.new
+    @wr_sheet = wr_book.create_worksheet
+  end
+
+  # list of unacceptable file names
+  NOT_FILENAMES = ["PROOF", "in+press"]
+  # list of acceptable creators
+  POST_PRINT_CREATORS = ["Microsoft", "LaTeX", "Preview", "TeX"]
+  # list of unacceptable creators
+  NOT_POST_PRINT_CREATORS = ["Elsevier", "Arbortext Advanced Print Publisher", "Springer", "Appligent"]
+  # list of unacceptable subjects
+  NOT_SUBJECTS = ["Journal Pre-proof"]
+  # list of unacceptable producers
+  NOT_PRODUCERS = ["iText"]
+
+  def verify
+    puts "loop over directory"
+    Dir.glob("#{directory_to_examine}/*.pdf").each_with_index do |file, file_index|
+
+      if file_index == 0
+        headings = ["File", "PDF File Status", "PDF Status Message", "PDF Verbose", "EXIF File Status", "EXIF Status Message", "Journal Article Version", "EXIF Verbose"]
+        wr_sheet.insert_row( file_index, headings )
+      else
+
+        next if File.directory?(file) # skip the loop if the file is a directory
+
+        base = File.basename(file)
+        wr_sheet.row(file_index).insert 0, base
+
+        pdf_validation = {}
+        pdf_validation = is_pdf_file_valid(file)
+        puts "PDF VALIDATION\n"
+        puts pdf_validation
+        puts "\n"
+
+        exif_validation = {}
+        exif_validation = is_exif_valid(file)
+        puts "EXIF VALIDATION\n"
+        puts exif_validation
+        puts "\n"
+
+        wr_sheet.row(file_index).insert 1, pdf_validation[:status]
+        wr_sheet.row(file_index).insert 2, pdf_validation[:message]
+        wr_sheet.row(file_index).insert 3, pdf_validation[:verbose].inspect
+
+        wr_sheet.row(file_index).insert 4, exif_validation[:status]
+        wr_sheet.row(file_index).insert 5, exif_validation[:message]
+        wr_sheet.row(file_index).insert 6, exif_validation[:verbose][:journal_article_version]
+        wr_sheet.row(file_index).insert 7, exif_validation[:verbose].inspect
+
+        if pdf_validation[:status].nil? and exif_validation[:status].nil?
+          puts "Couldn't determine\n\n"
+        elsif pdf_validation[:status]
+          puts "Passed Check (pdf)\n\n"
+        elsif exif_validation[:status]
+          puts "Passed Check (exif)\n\n"
+        else
+          puts "Failed\n\n"
+        end
+      end
+
+    end
+    wr_book.write save_spreadsheet_name
+    puts "Found #{@good_pdf} acceptable PDFs from PDF library"
+    puts "Found #{@good_exif} acceptable PDFs from EXIF library"
+  end
+
+  private
+
+    def is_pdf_file_valid(file_path)
+
+      validation = {}
+      validation[:status] = nil
+      validation[:message] = ""
+      validation[:verbose] = ""
+
+      if NOT_FILENAMES.any? { |s| file_path.include?(s) }
+        validation[:status] = false
+        validation[:message] = "Bad file name"
+        return validation
+      end
+
+      PDF::Reader.open(file_path) do |reader|
+        validation[:verbose] = reader.info
+        puts reader.info
+        if reader.info.key? (:Subject)
+          begin
+            if NOT_SUBJECTS.any? { |s| reader.info[:Subject].include?(s) }
+              validation[:status] = false #good = false
+              validation[:message] = "Bad Subject"
+              return validation
+            end
+          rescue NoMethodError => e
+            validation[:status] = false
+            validation[:message] = "Couldn't read subject"
+            return validation
+          rescue => e
+            validation[:status] = false
+            validation[:message] = "Couldn't read subject (Error)"
+            return validation
+          end
+        end
+        if reader.info.key? (:Creator) and reader.info[:Creator].is_a?(String)
+          if POST_PRINT_CREATORS.any? { |s| reader.info[:Creator].include?(s) }
+            @good_pdf += 1
+            validation[:status] = true #good = true
+            validation[:message] = "Found a good creator"
+            return validation
+          elsif NOT_POST_PRINT_CREATORS.any? { |s| reader.info[:Creator].include?(s) }
+            validation[:status] = false #good = false
+            validation[:message] = "Found a bad creator"
+            return validation
+          end
+        end
+      end
+      return validation
+    end
+
+    def is_exif_valid(file_path)
+      validation = {}
+      validation[:status] = nil
+      validation[:message] = ""
+      validation[:verbose] = ""
+
+      e = Exiftool.new(file_path)
+
+      puts "Exif:"
+      h = e.to_hash
+      validation[:verbose] = h
+      puts h[:journal_article_version]
+      if !h[:journal_article_version].nil?
+        # AM: accepted manuscript - pass
+        if h[:journal_article_version].downcase == "am"
+          @good_exif += 1
+          validation[:status] = true
+          validation[:message] = "accepted manuscript"
+          return validation
+        end
+        # P: proof - fail
+        if h[:journal_article_version].downcase == "p"
+          validation[:status] = false
+          validation[:message] = "proof"
+          return validation
+        end
+        # VoR: version of record - fail
+        if h[:journal_article_version].downcase == "vor"
+          validation[:status] = false
+          validation[:message] = "version of record"
+          return validation
+        end
+      end
+
+      if !h[:subject].nil? and h[:subject].is_a?(String) and h[:subject].downcase.include? "downloaded from"
+        validation[:status] = false
+        validation[:message] = "subject contains downloaded from"
+        return validation
+      end
+
+      if !h[:creator].nil? and h[:creator].is_a?(String)
+        if NOT_POST_PRINT_CREATORS.any? { |s| h[:creator].include?(s) }
+          validation[:status] = false
+          validation[:message] = "Found a bad creator"
+          return validation
+        end
+      end
+
+      if !h[:creator_tool].nil? and h[:creator_tool].is_a?(String)
+        if NOT_POST_PRINT_CREATORS.any? { |s| h[:creator_tool].include?(s) }
+          validation[:status] = false
+          validation[:message] = "Found a bad creator"
+          return validation
+        end
+      end
+
+      if !h[:producer].nil? and h[:producer].is_a?(String)
+        if NOT_PRODUCERS.any? { |s| h[:producer].include?(s) }
+          validation[:status] = false
+          validation[:message] = "Found a bad producer"
+          return validation
+        end
+      end
+
+      return validation
+    end
+
+    def directory_to_examine
+      "#{Rails.root}/app/post_prints"
+    end
+
+    def save_spreadsheet_name
+      "#{directory_to_examine}/exif-results-#{Time.now.strftime("%Y-%m-%d %H-%M")}.xls"
+    end
+
+    attr_accessor :wr_book, :wr_sheet
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -46,6 +46,9 @@
           <li class="nav-item">
             <a class="nav-link" href=<%=ai_backups_listing_path%>>AI Backups</a>
           </li>
+          <li class="nav-item">
+            <a class="nav-link" href=<%=post_prints_path%>>Post Prints Analyzer</a>
+          </li>
         </ul>
       </div>
     </div>

--- a/app/views/post_prints/_analysis_file.html.erb
+++ b/app/views/post_prints/_analysis_file.html.erb
@@ -1,0 +1,10 @@
+<br/>
+<% if @analysis_files.present? %>
+  <h3>
+    Last Analysis File
+  </h3>
+
+  <% @analysis_files.each do |file| %>
+    <p><%= link_to file.to_s, "post_prints/#{file}", download: file.to_s, target: '_blank' %></p>
+  <% end %>
+<% end %>

--- a/app/views/post_prints/_file_uploader.html.erb
+++ b/app/views/post_prints/_file_uploader.html.erb
@@ -1,0 +1,19 @@
+<div class="col-sm">
+  <%= form_with :url => { :action => "analyze" }, id: "post_print_analyzer" do |form| %>
+    <p>
+      <%= label(:post_print_file, text = "Post Prints CSV") %>
+      <%= form.file_field :post_print_file,
+                          required: true,
+                          accept: 'text/csv'%>
+    </p>
+    <div class="row">
+      <%= form.button "Analyze",
+                      class:"btn btn-primary",
+                      type: :submit,
+                      :data => {
+                          disable_with: "<i class='fa fa-spinner fa-pulse'></i> Analyzing...",
+                          :confirm => "Are you sure you want to analyze these post prints?  This may take a while."
+                      }%>
+    </div>
+  <% end %>
+</div>

--- a/app/views/post_prints/index.html.erb
+++ b/app/views/post_prints/index.html.erb
@@ -1,0 +1,8 @@
+<div class="center jumbotron text-center">
+  <h1>
+    Post Print Analyzer
+  </h1>
+</div>
+
+<%= render partial: 'file_uploader' %>
+<%= render partial: 'analysis_file' %>

--- a/config/activity_insight.yml.circleci
+++ b/config/activity_insight.yml.circleci
@@ -10,6 +10,8 @@ production:
     :password: "fake"
   metadata_db:
     :key: "fake"
+  s3_bucket:
+    api_key: "fake"
 
 development:
   main:
@@ -23,6 +25,8 @@ development:
     :password: "fake"
   metadata_db:
     :key: "fake"
+  s3_bucket:
+    api_key: "fake"
 
 test:
   main:
@@ -36,3 +40,5 @@ test:
     :password: "fake"
   metadata_db:
     :key: "fake"
+  s3_bucket:
+    api_key: "fake"

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -60,6 +60,7 @@ namespace :deploy do
       execute "ln -sf /rubytools/#{fetch(:application)}/config_#{fetch(:stage)}/#{fetch(:partner)}activity_insight.yml #{release_path}/config/activity_insight.yml"
       execute "ln -sf /rubytools/#{fetch(:application)}/config_#{fetch(:stage)}/#{fetch(:partner)}integration_passcode.yml #{release_path}/config/integration_passcode.yml"
       execute "mkdir #{release_path}/app/parsing_files"
+      execute "mkdir #{release_path}/app/post_prints"
     end
   end
   before "deploy:assets:precompile", "deploy:symlink_shared"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
   post '/ai_integration/delete_records', to: 'ai_integration#delete_records'
   get '/ai_backups_listing', to: 'ai_backups_listing#index'
   get '/ai_backups_listing/download', to: 'ai_backups_listing#download'
+  get '/post_prints', to: 'post_prints#index'
+  post '/post_prints', to: 'post_prints#analyze'
   resources :publication_listings do
     resources :works
     get '/destroy', to: 'publication_listings#destroy'

--- a/spec/models/post_print_analyzer_spec.rb
+++ b/spec/models/post_print_analyzer_spec.rb
@@ -30,7 +30,7 @@ describe PostPrintAnalyzer do
       it 'writes error to File' do
         allow_any_instance_of(Kernel).to receive(:system).and_return(false)
         analyzer.analyze
-        expect(File.read("#{Rails.root}/spec/fixtures/post_prints/errors.txt")).to eq "abc123/intellcont/test.pdf"
+        expect(File.read("#{Rails.root}/spec/fixtures/post_prints/errors.txt")).to eq "abc123/intellcont/test.pdf\n"
       end
     end
   end

--- a/spec/models/post_print_analyzer_spec.rb
+++ b/spec/models/post_print_analyzer_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+describe PostPrintAnalyzer do
+  let(:analyzer) { described_class.new(CSV.new("POST_FILE_1_DOC\nabc123/intellcont/test.pdf", headers: :first_row)) }
+  before do
+    clear_directory
+    allow(analyzer).to receive(:f_name).and_return('post_print_list.csv')
+    allow(analyzer).to receive(:f_path).and_return("#{Rails.root}/spec/fixtures/post_prints/post_print_list.csv")
+    allow(analyzer).to receive(:post_prints_directory).and_return("#{Rails.root}/spec/fixtures/post_prints")
+    allow(analyzer).to receive(:analysis_directory).and_return("#{Rails.root}/spec/fixtures/post_prints")
+    allow(analyzer).to receive(:clear_pp_files).and_return(true)
+    allow(analyzer).to receive(:clear_last_analysis).and_return(true)
+    allow_any_instance_of(VerifyPostPrint).to receive(:verify).and_return(true)
+  end
+
+  after do
+    clear_directory
+  end
+
+  describe 'analyze' do
+    context 'when no error is returned from system call' do
+      it 'does not write to error to File' do
+        allow_any_instance_of(Kernel).to receive(:system).and_return(true)
+        analyzer.analyze
+        expect(File.read("#{Rails.root}/spec/fixtures/post_prints/errors.txt")).to eq ""
+      end
+    end
+
+    context 'when an error is returned from system call' do
+      it 'writes error to File' do
+        allow_any_instance_of(Kernel).to receive(:system).and_return(false)
+        analyzer.analyze
+        expect(File.read("#{Rails.root}/spec/fixtures/post_prints/errors.txt")).to eq "abc123/intellcont/test.pdf"
+      end
+    end
+  end
+end
+
+def clear_directory
+  Dir.foreach("#{Rails.root}/spec/fixtures/post_prints") do |f|
+    fn = File.join("#{Rails.root}/spec/fixtures/post_prints", f)
+    File.delete(fn) if File.exist?(fn) && f != '.' && f != '..'
+  end
+end

--- a/spec/models/verify_post_print_spec.rb
+++ b/spec/models/verify_post_print_spec.rb
@@ -1,0 +1,324 @@
+require 'rails_helper'
+
+describe VerifyPostPrint do
+  let(:verify_post_print) { described_class.new }
+
+  describe "#is_pdf_file_valid" do
+    context 'when filename is bad' do
+      it 'returns a :status of false' do
+        verify1 = verify_post_print.send(:is_pdf_file_valid, 'test-PROOF.pdf')
+        expect(verify1[:status]).to eq false
+        expect(verify1[:message]).to eq "Bad file name"
+        verify2 = verify_post_print.send(:is_pdf_file_valid, 'test-in+press.pdf')
+        expect(verify2[:status]).to eq false
+        expect(verify2[:status]).to eq false
+        expect(verify2[:message]).to eq "Bad file name"
+      end
+    end
+
+    context 'when Subject is Journal Pre-proof' do
+      let(:pdf) do
+        { info: { Subject: "Journal Pre-proof" } }
+      end
+      it 'returns a :status of false' do
+        allow(PDF::Reader).to receive(:open).with('test.pdf').and_yield(double('PDF::Reader', pdf))
+        verify = verify_post_print.send(:is_pdf_file_valid, 'test.pdf')
+        expect(verify[:status]).to eq false
+        expect(verify[:message]).to eq "Bad Subject"
+      end
+    end
+
+    context 'when Creator is Elsevier' do
+      let(:pdf) do
+        { info: { Creator: "Elsevier" } }
+      end
+      it 'returns a :status of false' do
+        allow(PDF::Reader).to receive(:open).with('test.pdf').and_yield(double('PDF::Reader', pdf))
+        verify = verify_post_print.send(:is_pdf_file_valid, 'test.pdf')
+        expect(verify[:status]).to eq false
+        expect(verify[:message]).to eq "Found a bad creator"
+      end
+    end
+
+    context 'when Creator is Arbortext Advanced Print Publisher' do
+      let(:pdf) do
+        { info: { Creator: "Arbortext Advanced Print Publisher" } }
+      end
+      it 'returns a :status of false' do
+        allow(PDF::Reader).to receive(:open).with('test.pdf').and_yield(double('PDF::Reader', pdf))
+        verify = verify_post_print.send(:is_pdf_file_valid, 'test.pdf')
+        expect(verify[:status]).to eq false
+        expect(verify[:message]).to eq "Found a bad creator"
+      end
+    end
+
+    context 'when Creator is Springer' do
+      let(:pdf) do
+        { info: { Creator: "Springer" } }
+      end
+      it 'returns a :status of false' do
+        allow(PDF::Reader).to receive(:open).with('test.pdf').and_yield(double('PDF::Reader', pdf))
+        verify = verify_post_print.send(:is_pdf_file_valid, 'test.pdf')
+        expect(verify[:status]).to eq false
+        expect(verify[:message]).to eq "Found a bad creator"
+      end
+    end
+
+    context 'when Creator is Appligent' do
+      let(:pdf) do
+        { info: { Creator: "Appligent" } }
+      end
+      it 'returns a :status of false' do
+        allow(PDF::Reader).to receive(:open).with('test.pdf').and_yield(double('PDF::Reader', pdf))
+        verify = verify_post_print.send(:is_pdf_file_valid, 'test.pdf')
+        expect(verify[:status]).to eq false
+        expect(verify[:message]).to eq "Found a bad creator"
+      end
+    end
+
+    context 'when Creator is Microsoft' do
+      let(:pdf) do
+        { info: { Creator: "Microsoft" } }
+      end
+      it 'returns a :status of true' do
+        allow(PDF::Reader).to receive(:open).with('test.pdf').and_yield(double('PDF::Reader', pdf))
+        verify = verify_post_print.send(:is_pdf_file_valid, 'test.pdf')
+        expect(verify[:status]).to eq true
+        expect(verify[:message]).to eq "Found a good creator"
+      end
+    end
+
+    context 'when Creator is LaTeX' do
+      let(:pdf) do
+        { info: { Creator: "LaTeX" } }
+      end
+      it 'returns a :status of true' do
+        allow(PDF::Reader).to receive(:open).with('test.pdf').and_yield(double('PDF::Reader', pdf))
+        verify = verify_post_print.send(:is_pdf_file_valid, 'test.pdf')
+        expect(verify[:status]).to eq true
+        expect(verify[:message]).to eq "Found a good creator"
+      end
+    end
+
+    context 'when Creator is Preview' do
+      let(:pdf) do
+        { info: { Creator: "Preview" } }
+      end
+      it 'returns a :status of true' do
+        allow(PDF::Reader).to receive(:open).with('test.pdf').and_yield(double('PDF::Reader', pdf))
+        verify = verify_post_print.send(:is_pdf_file_valid, 'test.pdf')
+        expect(verify[:status]).to eq true
+        expect(verify[:message]).to eq "Found a good creator"
+      end
+    end
+
+    context 'when Creator is TeX' do
+      let(:pdf) do
+        { info: { Creator: "TeX" } }
+      end
+      it 'returns a :status of true' do
+        allow(PDF::Reader).to receive(:open).with('test.pdf').and_yield(double('PDF::Reader', pdf))
+        verify = verify_post_print.send(:is_pdf_file_valid, 'test.pdf')
+        expect(verify[:status]).to eq true
+        expect(verify[:message]).to eq "Found a good creator"
+      end
+    end
+
+    context 'when nothing to parse' do
+      let(:pdf) do
+        { info: {} }
+      end
+
+      it 'returns a :status of false' do
+        allow(PDF::Reader).to receive(:open).with('test.pdf').and_yield(double('PDF::Reader', pdf))
+        verify = verify_post_print.send(:is_pdf_file_valid, 'test.pdf')
+        expect(verify[:status]).to eq nil
+        expect(verify[:message]).to eq ""
+      end
+    end
+  end
+
+  describe "#is_exif_valid" do
+    context 'when journal_article_version is "AM"' do
+      let(:exif_hash) do
+        { journal_article_version: "AM" }
+      end
+
+      it 'returns a :status of true' do
+        allow(Exiftool).to receive_message_chain(:new, :to_hash).and_return(exif_hash)
+        verify = verify_post_print.send(:is_exif_valid, 'test.pdf')
+        expect(verify[:status]).to eq true
+        expect(verify[:message]).to eq "accepted manuscript"
+      end
+    end
+
+    context 'when journal_article_version is "P"' do
+      let(:exif_hash) do
+        { journal_article_version: "P" }
+      end
+
+      it 'returns a :status of false' do
+        allow(Exiftool).to receive_message_chain(:new, :to_hash).and_return(exif_hash)
+        verify = verify_post_print.send(:is_exif_valid, 'test.pdf')
+        expect(verify[:status]).to eq false
+        expect(verify[:message]).to eq "proof"
+      end
+    end
+
+    context 'when journal_article_version is "VOR"' do
+      let(:exif_hash) do
+        { journal_article_version: "VOR" }
+      end
+
+      it 'returns a :status of false' do
+        allow(Exiftool).to receive_message_chain(:new, :to_hash).and_return(exif_hash)
+        verify = verify_post_print.send(:is_exif_valid, 'test.pdf')
+        expect(verify[:status]).to eq false
+        expect(verify[:message]).to eq "version of record"
+      end
+    end
+
+    context 'when subject contains "downloaded from"' do
+      let(:exif_hash) do
+        { subject: "downloaded from acbd1234" }
+      end
+
+      it 'returns a :status of false' do
+        allow(Exiftool).to receive_message_chain(:new, :to_hash).and_return(exif_hash)
+        verify = verify_post_print.send(:is_exif_valid, 'test.pdf')
+        expect(verify[:status]).to eq false
+        expect(verify[:message]).to eq "subject contains downloaded from"
+      end
+    end
+
+    context 'when creator is "Elsevier"' do
+      let(:exif_hash) do
+        { creator: "Elsevier" }
+      end
+
+      it 'returns a :status of false' do
+        allow(Exiftool).to receive_message_chain(:new, :to_hash).and_return(exif_hash)
+        verify = verify_post_print.send(:is_exif_valid, 'test.pdf')
+        expect(verify[:status]).to eq false
+        expect(verify[:message]).to eq "Found a bad creator"
+      end
+    end
+
+    context 'when creator is "Arbortext Advanced Print Publisher"' do
+      let(:exif_hash) do
+        { creator: "Arbortext Advanced Print Publisher" }
+      end
+
+      it 'returns a :status of false' do
+        allow(Exiftool).to receive_message_chain(:new, :to_hash).and_return(exif_hash)
+        verify = verify_post_print.send(:is_exif_valid, 'test.pdf')
+        expect(verify[:status]).to eq false
+        expect(verify[:message]).to eq "Found a bad creator"
+      end
+    end
+
+    context 'when creator is "Springer"' do
+      let(:exif_hash) do
+        { creator: "Springer" }
+      end
+
+      it 'returns a :status of false' do
+        allow(Exiftool).to receive_message_chain(:new, :to_hash).and_return(exif_hash)
+        verify = verify_post_print.send(:is_exif_valid, 'test.pdf')
+        expect(verify[:status]).to eq false
+        expect(verify[:message]).to eq "Found a bad creator"
+      end
+    end
+
+    context 'when creator is "Appligent"' do
+      let(:exif_hash) do
+        { creator: "Appligent" }
+      end
+
+      it 'returns a :status of false' do
+        allow(Exiftool).to receive_message_chain(:new, :to_hash).and_return(exif_hash)
+        verify = verify_post_print.send(:is_exif_valid, 'test.pdf')
+        expect(verify[:status]).to eq false
+        expect(verify[:message]).to eq "Found a bad creator"
+      end
+    end
+
+    context 'when creator_tool is "Appligent"' do
+      let(:exif_hash) do
+        { creator_tool: "Appligent" }
+      end
+
+      it 'returns a :status of false' do
+        allow(Exiftool).to receive_message_chain(:new, :to_hash).and_return(exif_hash)
+        verify = verify_post_print.send(:is_exif_valid, 'test.pdf')
+        expect(verify[:status]).to eq false
+        expect(verify[:message]).to eq "Found a bad creator"
+      end
+    end
+
+    context 'when creator_tool is "Elsevier"' do
+      let(:exif_hash) do
+        { creator_tool: "Elsevier" }
+      end
+
+      it 'returns a :status of false' do
+        allow(Exiftool).to receive_message_chain(:new, :to_hash).and_return(exif_hash)
+        verify = verify_post_print.send(:is_exif_valid, 'test.pdf')
+        expect(verify[:status]).to eq false
+        expect(verify[:message]).to eq "Found a bad creator"
+      end
+    end
+
+    context 'when creator_tool is "Arbortext Advanced Print Publisher"' do
+      let(:exif_hash) do
+        { creator_tool: "Arbortext Advanced Print Publisher" }
+      end
+
+      it 'returns a :status of false' do
+        allow(Exiftool).to receive_message_chain(:new, :to_hash).and_return(exif_hash)
+        verify = verify_post_print.send(:is_exif_valid, 'test.pdf')
+        expect(verify[:status]).to eq false
+        expect(verify[:message]).to eq "Found a bad creator"
+      end
+    end
+
+    context 'when creator_tool is "Springer"' do
+      let(:exif_hash) do
+        { creator_tool: "Springer" }
+      end
+
+      it 'returns a :status of false' do
+        allow(Exiftool).to receive_message_chain(:new, :to_hash).and_return(exif_hash)
+        verify = verify_post_print.send(:is_exif_valid, 'test.pdf')
+        expect(verify[:status]).to eq false
+        expect(verify[:message]).to eq "Found a bad creator"
+      end
+    end
+
+    context 'when producer is "iText"' do
+      let(:exif_hash) do
+        { producer: "iText" }
+      end
+
+      it 'returns a :status of false' do
+        allow(Exiftool).to receive_message_chain(:new, :to_hash).and_return(exif_hash)
+        verify = verify_post_print.send(:is_exif_valid, 'test.pdf')
+        expect(verify[:status]).to eq false
+        expect(verify[:message]).to eq "Found a bad producer"
+      end
+    end
+
+    context 'when nothing to parse' do
+      let(:exif_hash) do
+        {}
+      end
+
+      it 'returns a :status of false' do
+        allow(Exiftool).to receive_message_chain(:new, :to_hash).and_return(exif_hash)
+        verify = verify_post_print.send(:is_exif_valid, 'test.pdf')
+        expect(verify[:status]).to eq nil
+        expect(verify[:message]).to eq ''
+      end
+    end
+  end
+end


### PR DESCRIPTION
Phase 2 of post print project.  Closes #20 

Adds "Post Print Analyzer" page where user can upload the post print csv with paths to post prints in S3.  When "Analyze" button is pressed, the csv is parsed, the paths are used to pull down the post prints, store them in a directory, analyze them with the post print verify tool, then compress all the post print and analysis files and allow the user to download this compressed file.
![Screen Shot 2022-05-18 at 10 02 29 AM](https://user-images.githubusercontent.com/32677188/169060149-23b7e3cb-e875-426f-a979-0250cb1c54ab.png)
